### PR TITLE
Support external editors

### DIFF
--- a/BowlerBuilder/KotlinUI/src/main/kotlin/com/neuronrobotics/bowlerbuilder/controller/gitmenu/PublishController.kt
+++ b/BowlerBuilder/KotlinUI/src/main/kotlin/com/neuronrobotics/bowlerbuilder/controller/gitmenu/PublishController.kt
@@ -19,19 +19,12 @@ class PublishController : Controller() {
      * Publish updates to a file.
      *
      * @param file The file on disk to the updated [content] to.
-     * @param content The new file contents.
      * @param commitMessage The commit message.
      */
-    fun publish(
-        file: File,
-        content: String,
-        commitMessage: String
-    ) {
+    fun publish(file: File, commitMessage: String) {
         val repo = RepositoryBuilder()
             .findGitDir(file)
             .build()
-
-        file.writeText(content)
 
         val git = Git(repo)
         git.commit()

--- a/BowlerBuilder/KotlinUI/src/main/kotlin/com/neuronrobotics/bowlerbuilder/model/WatchedFile.kt
+++ b/BowlerBuilder/KotlinUI/src/main/kotlin/com/neuronrobotics/bowlerbuilder/model/WatchedFile.kt
@@ -1,0 +1,109 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.neuronrobotics.bowlerbuilder.model
+
+import com.neuronrobotics.bowlerbuilder.controller.util.LoggerUtilities
+import java.io.File
+import java.nio.file.Path
+import java.nio.file.StandardWatchEventKinds.ENTRY_CREATE
+import java.nio.file.StandardWatchEventKinds.ENTRY_DELETE
+import java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY
+import java.nio.file.StandardWatchEventKinds.OVERFLOW
+import java.nio.file.WatchEvent
+import java.nio.file.WatchService
+import kotlin.concurrent.thread
+
+enum class WatchedFileChange {
+    MODIFIED, DELETED, NOTHING
+}
+
+/**
+ * A file paired with a [WatchService].
+ *
+ * @param file The file to watch.
+ */
+internal class WatchedFile
+internal constructor(
+    val file: File
+) {
+
+    private var lastEvent: WatchEvent<Path>? = null
+
+    init {
+        require(file.isFile) {
+            "The supplied file must be a normal file."
+        }
+
+        require(file.parentFile.isDirectory) {
+            "The supplied file's parent file must be a directory."
+        }
+
+        thread(isDaemon = true) {
+            file.toPath().fileSystem.newWatchService().use { watchService ->
+                /**
+                 * Need to register both [ENTRY_CREATE] and [ENTRY_MODIFY]. Some editors
+                 * overwrite the whole file (like gedit) and other modify the file on disk (like
+                 * vim).
+                 */
+                file.parentFile.toPath().register(
+                    watchService,
+                    ENTRY_CREATE,
+                    ENTRY_DELETE,
+                    ENTRY_MODIFY
+                )
+
+                while (true) {
+                    val wk = watchService.take()
+
+                    wk.pollEvents().forEach {
+                        @Suppress("UNCHECKED_CAST")
+                        if (it.kind() != OVERFLOW) {
+                            // Javadocs says this cast is fine
+                            it as WatchEvent<Path>
+
+                            if (it.context().endsWith(file.name)) {
+                                lastEvent = it
+                            }
+                        }
+                    }
+
+                    val valid = wk.reset()
+                    if (!valid) {
+                        throw IllegalStateException(
+                            """
+                            |Watched directory became invalid.
+                            |File path: ${file.absolutePath}
+                            """.trimMargin()
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns the most recent file change event.
+     *
+     * @return The most recent file change event.
+     */
+    fun wasFileChangedSinceLastCheck(): WatchedFileChange =
+        when (lastEvent?.kind()) {
+            ENTRY_CREATE, ENTRY_MODIFY -> {
+                lastEvent = null
+                WatchedFileChange.MODIFIED
+            }
+            ENTRY_DELETE -> {
+                lastEvent = null
+                WatchedFileChange.DELETED
+            }
+            null -> WatchedFileChange.NOTHING
+            else -> throw IllegalStateException("Unknown event: $lastEvent")
+        }
+
+    companion object {
+        private val LOGGER = LoggerUtilities.getLogger(WatchedFile::class.java.simpleName)
+    }
+}

--- a/BowlerBuilder/KotlinUI/src/main/kotlin/com/neuronrobotics/bowlerbuilder/view/gitmenu/PublishView.kt
+++ b/BowlerBuilder/KotlinUI/src/main/kotlin/com/neuronrobotics/bowlerbuilder/view/gitmenu/PublishView.kt
@@ -18,9 +18,7 @@ import java.io.File
  * A form to commit and push changes to a file.
  */
 class PublishView(
-    private val gitUrl: String,
-    private val file: File,
-    private val scriptContent: String
+    private val file: File
 ) : Fragment() {
 
     private val controller: PublishController by inject()
@@ -41,7 +39,7 @@ class PublishView(
             button("Push") {
                 action {
                     runAsync {
-                        controller.publish(file, scriptContent, commitMessage)
+                        controller.publish(file, commitMessage)
                     } success {
                         LOGGER.info { "Push successful." }
                         close()
@@ -64,8 +62,6 @@ class PublishView(
     companion object {
         private val LOGGER = LoggerUtilities.getLogger(PublishView::class.java.simpleName)
 
-        fun create(gitUrl: String, file: File, fullText: String) = PublishView(
-            gitUrl, file, fullText
-        )
+        fun create(file: File) = PublishView(file)
     }
 }

--- a/BowlerBuilder/KotlinUI/src/main/kotlin/com/neuronrobotics/bowlerbuilder/view/main/MainWindowView.kt
+++ b/BowlerBuilder/KotlinUI/src/main/kotlin/com/neuronrobotics/bowlerbuilder/view/main/MainWindowView.kt
@@ -188,13 +188,19 @@ class MainWindowView : View() {
     }
 
     /**
-     * Searches for tabs by their [Tab.content] and removes all matches.
+     * Searches for tabs by their [Tab.content] and all of the content's children and removes all
+     * matches.
      *
      * @param cmp The [Tab.content] to search for.
      */
     fun closeTabByContent(cmp: Node) {
         fun removeMatches(tabPane: TabPane) {
-            val matches = tabPane.tabs.filter { it.content == cmp }
+            fun findMatchInChildren(node: Node): Boolean =
+                node == cmp || node.getChildList()?.fold(false) { acc, elem ->
+                    acc || findMatchInChildren(elem)
+                } ?: false
+
+            val matches = tabPane.tabs.filter { findMatchInChildren(it.content) }
             runLater { tabPane.tabs.removeAll(matches) }
         }
 

--- a/BowlerBuilder/KotlinUI/src/main/kotlin/com/neuronrobotics/bowlerbuilder/view/scripteditor/AceEditorView.kt
+++ b/BowlerBuilder/KotlinUI/src/main/kotlin/com/neuronrobotics/bowlerbuilder/view/scripteditor/AceEditorView.kt
@@ -81,6 +81,10 @@ class AceEditorView
             button("Copy URL").action {
                 clipboard.putString(urlTextField.text)
             }
+
+            button("Copy Path").action {
+                clipboard.putString(file.absolutePath)
+            }
         }
     }
 

--- a/BowlerBuilder/KotlinUI/src/main/kotlin/com/neuronrobotics/bowlerbuilder/view/scripteditor/AceEditorView.kt
+++ b/BowlerBuilder/KotlinUI/src/main/kotlin/com/neuronrobotics/bowlerbuilder/view/scripteditor/AceEditorView.kt
@@ -125,7 +125,8 @@ class AceEditorView
                             }
                         ).openModal(
                             modality = Modality.WINDOW_MODAL,
-                            escapeClosesWindow = false
+                            escapeClosesWindow = false,
+                            block = true
                         )
                     }
 
@@ -142,7 +143,8 @@ class AceEditorView
                             }
                         ).openModal(
                             modality = Modality.WINDOW_MODAL,
-                            escapeClosesWindow = false
+                            escapeClosesWindow = false,
+                            block = true
                         )
                     }
 

--- a/BowlerBuilder/KotlinUI/src/main/kotlin/com/neuronrobotics/bowlerbuilder/view/scripteditor/AceEditorView.kt
+++ b/BowlerBuilder/KotlinUI/src/main/kotlin/com/neuronrobotics/bowlerbuilder/view/scripteditor/AceEditorView.kt
@@ -5,6 +5,7 @@
  */
 package com.neuronrobotics.bowlerbuilder.view.scripteditor
 
+import com.neuronrobotics.bowlerbuilder.controller.main.MainWindowController
 import com.neuronrobotics.bowlerbuilder.controller.main.MainWindowController.Companion.getInstanceOf
 import com.neuronrobotics.bowlerbuilder.controller.scripteditor.AceEditorController
 import com.neuronrobotics.bowlerbuilder.controller.scripteditor.ScriptEditor
@@ -12,6 +13,7 @@ import com.neuronrobotics.bowlerbuilder.controller.scripteditor.VisualScriptEdit
 import com.neuronrobotics.bowlerbuilder.model.WatchedFile
 import com.neuronrobotics.bowlerbuilder.model.WatchedFileChange
 import com.neuronrobotics.bowlerbuilder.view.gitmenu.PublishView
+import com.neuronrobotics.bowlerbuilder.view.main.event.CloseTabByContentEvent
 import com.neuronrobotics.bowlerbuilder.view.util.FxUtil
 import com.neuronrobotics.bowlerbuilder.view.util.ThreadMonitoringButton
 import com.neuronrobotics.bowlerbuilder.view.util.loadImageAsset
@@ -128,7 +130,17 @@ class AceEditorView
                     }
 
                     WatchedFileChange.DELETED -> runLater {
-                        FileDeletedOnDiskView().openModal(
+                        FileDeletedOnDiskView(
+                            {
+                                val text = getFullText()
+                                runAsync { watchedFile.writeText(text) }
+                            },
+                            {
+                                MainWindowController.mainUIEventBus.post(
+                                    CloseTabByContentEvent(root)
+                                )
+                            }
+                        ).openModal(
                             modality = Modality.WINDOW_MODAL,
                             escapeClosesWindow = false
                         )

--- a/BowlerBuilder/KotlinUI/src/main/kotlin/com/neuronrobotics/bowlerbuilder/view/scripteditor/FileDeletedOnDiskView.kt
+++ b/BowlerBuilder/KotlinUI/src/main/kotlin/com/neuronrobotics/bowlerbuilder/view/scripteditor/FileDeletedOnDiskView.kt
@@ -1,0 +1,25 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.neuronrobotics.bowlerbuilder.view.scripteditor
+
+import tornadofx.*
+
+class FileDeletedOnDiskView : Fragment() {
+
+    override val root = form {
+        fieldset("File deleted on disk.") {
+            field("The file open in the editor was deleted on disk.") {
+                button("Keep file").action {
+                    TODO()
+                }
+
+                button("Remove file").action {
+                    TODO()
+                }
+            }
+        }
+    }
+}

--- a/BowlerBuilder/KotlinUI/src/main/kotlin/com/neuronrobotics/bowlerbuilder/view/scripteditor/FileDeletedOnDiskView.kt
+++ b/BowlerBuilder/KotlinUI/src/main/kotlin/com/neuronrobotics/bowlerbuilder/view/scripteditor/FileDeletedOnDiskView.kt
@@ -7,17 +7,22 @@ package com.neuronrobotics.bowlerbuilder.view.scripteditor
 
 import tornadofx.*
 
-class FileDeletedOnDiskView : Fragment() {
+class FileDeletedOnDiskView(
+    onKeepFile: () -> Unit,
+    onRemoveFile: () -> Unit
+) : Fragment() {
 
     override val root = form {
         fieldset("File deleted on disk.") {
             field("The file open in the editor was deleted on disk.") {
                 button("Keep file").action {
-                    TODO()
+                    onKeepFile()
+                    close()
                 }
 
                 button("Remove file").action {
-                    TODO()
+                    onRemoveFile()
+                    close()
                 }
             }
         }

--- a/BowlerBuilder/KotlinUI/src/main/kotlin/com/neuronrobotics/bowlerbuilder/view/scripteditor/FileModifiedOnDiskView.kt
+++ b/BowlerBuilder/KotlinUI/src/main/kotlin/com/neuronrobotics/bowlerbuilder/view/scripteditor/FileModifiedOnDiskView.kt
@@ -1,0 +1,30 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.neuronrobotics.bowlerbuilder.view.scripteditor
+
+import tornadofx.*
+
+class FileModifiedOnDiskView(
+    onKeepEditor: () -> Unit,
+    onKeepDisk: () -> Unit
+) : Fragment() {
+
+    override val root = form {
+        fieldset("File modified on disk.") {
+            field("The file open in the editor was modified on disk.") {
+                button("Keep contents from editor").action {
+                    onKeepEditor()
+                    close()
+                }
+
+                button("Keep contents from disk").action {
+                    onKeepDisk()
+                    close()
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description of the Change

This PR adds support for editing scripts in external editors. Everything in #46 has been implemented except for 2i, which I am not adding until it becomes a problem.

### Benefits

The workflow for editing scripts in external editors is now massively simpler and easier.

### Possible Drawbacks

My current implementation of autosave might not work well with very large files. External editors that spam file writes will cause a lot of file contents divergence prompts (not really any way around this, though).

### Verification Process

This was verified by hand.

### Applicable Issues

Closes #46.
