### PR TITLE
Add a workaround for the fx thread exploding

### DIFF
--- a/BowlerBuilder/KotlinUI/KotlinUI.gradle.kts
+++ b/BowlerBuilder/KotlinUI/KotlinUI.gradle.kts
@@ -22,7 +22,7 @@ repositories {
 
 dependencies {
     api(group = "com.neuronrobotics", name = "bowler-kernel-kinematics", version = kernel_version)
-    api(group = "com.neuronrobotics", name = "bowler-cad-core", version = "0.0.7")
+    api(group = "com.neuronrobotics", name = "bowler-cad-core", version = "0.0.8")
     api(group = "com.neuronrobotics", name = "java-bowler", version = "3.26.2")
     api(group = "io.arrow-kt", name = "arrow-core", version = arrow_version)
 

--- a/BowlerBuilder/KotlinUI/src/main/kotlin/com/neuronrobotics/bowlerbuilder/view/cad/cadengine/bowlercadengine/BowlerCadEngine.kt
+++ b/BowlerBuilder/KotlinUI/src/main/kotlin/com/neuronrobotics/bowlerbuilder/view/cad/cadengine/bowlercadengine/BowlerCadEngine.kt
@@ -74,7 +74,7 @@ import kotlin.concurrent.thread
 /**
  * CAD Engine from BowlerStudio.
  */
-@SuppressWarnings("TooGenericExceptionCaught")
+@SuppressWarnings("TooGenericExceptionCaught", "TooManyFunctions", "LargeClass")
 class BowlerCadEngine : Pane() {
 
     private val csgManager = CSGManager()
@@ -333,6 +333,7 @@ class BowlerCadEngine : Pane() {
      *
      * @param csg CSG to add
      */
+    @SuppressWarnings("ComplexMethod")
     fun addCSG(csg: CSG) {
         if (csgManager.has(csg)) {
             return

--- a/BowlerBuilder/KotlinUI/src/main/kotlin/com/neuronrobotics/bowlerbuilder/view/cad/cadengine/bowlercadengine/CSGManager.kt
+++ b/BowlerBuilder/KotlinUI/src/main/kotlin/com/neuronrobotics/bowlerbuilder/view/cad/cadengine/bowlercadengine/CSGManager.kt
@@ -21,6 +21,7 @@ import eu.mihosoft.vrl.v3d.CSG
 import javafx.scene.shape.MeshView
 import java.util.concurrent.ConcurrentHashMap
 
+@SuppressWarnings("TooManyFunctions")
 class CSGManager {
     private val csgToMeshView: MutableMap<CSG, MeshView>
     private val csgNameToMeshView: MutableMap<String, MeshView>

--- a/BowlerBuilder/KotlinUI/src/main/kotlin/com/neuronrobotics/bowlerbuilder/view/gitmenu/PublishView.kt
+++ b/BowlerBuilder/KotlinUI/src/main/kotlin/com/neuronrobotics/bowlerbuilder/view/gitmenu/PublishView.kt
@@ -36,6 +36,7 @@ class PublishView(
     private val commitMessageProperty = SimpleStringProperty("")
     private var commitMessage by commitMessageProperty
 
+    @SuppressWarnings("LabeledExpression")
     override val root = form {
         fieldset("Commit", labelPosition = Orientation.VERTICAL) {
             field("Commit Message", Orientation.VERTICAL) {

--- a/BowlerBuilder/KotlinUI/src/main/kotlin/com/neuronrobotics/bowlerbuilder/view/main/MainWindowView.kt
+++ b/BowlerBuilder/KotlinUI/src/main/kotlin/com/neuronrobotics/bowlerbuilder/view/main/MainWindowView.kt
@@ -33,6 +33,7 @@ import com.neuronrobotics.bowlerbuilder.view.gitmenu.GistFileSelectionView
 import com.neuronrobotics.bowlerbuilder.view.gitmenu.LogInView
 import com.neuronrobotics.bowlerbuilder.view.main.event.AddCadObjectsToCurrentTabEvent
 import com.neuronrobotics.bowlerbuilder.view.main.event.AddTabEvent
+import com.neuronrobotics.bowlerbuilder.view.main.event.CadViewExplodedEvent
 import com.neuronrobotics.bowlerbuilder.view.main.event.CloseTabByContentEvent
 import com.neuronrobotics.bowlerbuilder.view.main.event.SetCadObjectsToCurrentTabEvent
 import com.neuronrobotics.bowlerbuilder.view.newtab.NewTabTab
@@ -52,6 +53,7 @@ import tornadofx.*
 import javax.inject.Singleton
 import kotlin.concurrent.thread
 
+@SuppressWarnings("TooManyFunctions", "LargeClass")
 @Singleton
 class MainWindowView : View() {
 
@@ -181,6 +183,17 @@ class MainWindowView : View() {
     @Subscribe
     fun onSetCadObjectsToCurrentTabEvent(event: SetCadObjectsToCurrentTabEvent) =
         setCadObjectsToCurrentTab(event.cad)
+
+    @Subscribe
+    fun onCadViewExplodedEvent(event: CadViewExplodedEvent) {
+        val selection = mainTabPane.selectionModel.selectedItem
+        if (selection is CadScriptEditorTab) {
+            val newCadView = CadView()
+            newCadView.engine.addAllCSGs(selection.editor.cadView.engine.getCsgMap().keys)
+            selection.editor.cadView.replaceWith(newCadView)
+            selection.editor.setRegenerateRoot(newCadView)
+        }
+    }
 
     /**
      * Adds a tab to the [mainTabPane] and selects it.

--- a/BowlerBuilder/KotlinUI/src/main/kotlin/com/neuronrobotics/bowlerbuilder/view/main/event/CadViewExplodedEvent.kt
+++ b/BowlerBuilder/KotlinUI/src/main/kotlin/com/neuronrobotics/bowlerbuilder/view/main/event/CadViewExplodedEvent.kt
@@ -1,0 +1,23 @@
+/*
+ * This file is part of BowlerBuilder.
+ *
+ * BowlerBuilder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BowlerBuilder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BowlerBuilder.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.neuronrobotics.bowlerbuilder.view.main.event
+
+/**
+ * Causes the currently selected cad view to be replaced with a new one containing the same CSG's
+ * in the event that the JavaFX thread explodes.
+ */
+object CadViewExplodedEvent

--- a/BowlerBuilder/KotlinUI/src/main/kotlin/com/neuronrobotics/bowlerbuilder/view/scripteditor/CadScriptEditor.kt
+++ b/BowlerBuilder/KotlinUI/src/main/kotlin/com/neuronrobotics/bowlerbuilder/view/scripteditor/CadScriptEditor.kt
@@ -19,19 +19,44 @@ package com.neuronrobotics.bowlerbuilder.view.scripteditor
 import com.neuronrobotics.bowlerbuilder.controller.scripteditor.VisualScriptEditor
 import com.neuronrobotics.bowlerbuilder.view.cad.CadView
 import javafx.geometry.Orientation
+import javafx.scene.control.SplitPane
 import tornadofx.*
 import javax.inject.Inject
 
+@SuppressWarnings("SpreadOperator")
 class CadScriptEditor
 @Inject constructor(
     val editor: VisualScriptEditor
 ) : Fragment() {
 
-    val cadView = CadView()
+    private var regenRoot = false
+    var cadView = CadView()
 
-    @SuppressWarnings("SpreadOperator")
-    override val root = splitpane(
+    private var lastRoot: SplitPane = splitpane(
         orientation = Orientation.HORIZONTAL,
         nodes = *arrayOf(editor.root, cadView.root)
     )
+
+    override val root: SplitPane
+        get() {
+            if (regenRoot) {
+                regenRoot = false
+
+                lastRoot = splitpane(
+                    orientation = Orientation.HORIZONTAL,
+                    nodes = *arrayOf(editor.root, cadView.root)
+                )
+            }
+
+            return lastRoot
+        }
+
+    /**
+     * Sets a flag that the next time [root] is accessed it should be regenerated so that the
+     * [newCadView] is used instead of the old one.
+     */
+    fun setRegenerateRoot(newCadView: CadView) {
+        regenRoot = true
+        cadView = newCadView
+    }
 }


### PR DESCRIPTION
### Description of the Change

When the JavaFX thread computes a node's layout bounds, sometimes it throws an NPE or an AIOOBE every repaint iteration. This persists until the offending node is removed from the scene graph. This is a few years old bug that I can't fix, so my workaround here is to swap the entire 3d view for a new one when we see those exceptions.

### Verification Process

I tested this by hand and it correctly sees the FX thread exploding and remakes the 3d view. The 3d view freezes for around a second before coming back to life. It's better than crashing the entire tab at least.

### Applicable Issues

None.
